### PR TITLE
nginx: automatic redirection of HTTP traffic to HTTPS

### DIFF
--- a/guide/bitcoin/blockchain-explorer.md
+++ b/guide/bitcoin/blockchain-explorer.md
@@ -57,19 +57,21 @@ It's a database-free, self-hosted Bitcoin blockchain explorer, querying Bitcoin 
 In the [Security section](../system/security.md#prepare-nginx-reverse-proxy), we set up NGINX as a reverse proxy.
 Now we can add the BTC RPC Explorer configuration.
 
-* Enable NGINX reverse proxy to route external encrypted HTTPS traffic internally to the BTC RPC Explorer
+* Enable NGINX reverse proxy to route external encrypted HTTPS traffic internally to the BTC RPC Explorer.
+  The `error_page 497` directive instructs browsers that send HTTP requests to resend them over HTTPS.
 
   ```sh
-  $ sudo nano /etc/nginx/streams-enabled/btcrpcexplorer-reverse-proxy.conf
+  $ sudo nano /etc/nginx/sites-enabled/btcrpcexplorer-reverse-proxy.conf
   ```
 
   ```nginx
-  upstream btcrpcexplorer {
-    server 127.0.0.1:3002;
-  }
   server {
     listen 4000 ssl;
-    proxy_pass btcrpcexplorer;
+    error_page 497 =301 https://$host:$server_port$request_uri;
+
+    location / {
+      proxy_pass http://127.0.0.1:3002;
+    }
   }
   ```
 

--- a/guide/bonus/lightning/ride-the-lightning.md
+++ b/guide/bonus/lightning/ride-the-lightning.md
@@ -55,16 +55,17 @@ Now we can add the RTL configuration.
 * Enable NGINX reverse proxy to route external encrypted HTTPS traffic internally to RTL
 
   ```sh
-  $ sudo nano /etc/nginx/streams-enabled/rtl-reverse-proxy.conf
+  $ sudo nano /etc/nginx/sites-enabled/rtl-reverse-proxy.conf
   ```
 
   ```sh
-  upstream rtl {
-    server 127.0.0.1:3000;
-  }
   server {
     listen 4001 ssl;
-    proxy_pass rtl;
+    error_page 497 =301 https://$host:$server_port$request_uri;
+
+    location / {
+      proxy_pass http://127.0.0.1:3000;
+    }
   }
   ```
 

--- a/guide/system/security.md
+++ b/guide/system/security.md
@@ -179,10 +179,20 @@ This setup is called a "reverse proxy": NGINX provides secure communication to t
     worker_connections 768;
   }
 
+  http {
+    ssl_certificate /etc/ssl/certs/nginx-selfsigned.crt;
+    ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;
+    ssl_session_cache shared:HTTP-TLS:1m;
+    ssl_session_timeout 4h;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    include /etc/nginx/sites-enabled/*.conf;
+  }
+
   stream {
     ssl_certificate /etc/ssl/certs/nginx-selfsigned.crt;
     ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;
-    ssl_session_cache shared:SSL:1m;
+    ssl_session_cache shared:STREAM-TLS:1m;
     ssl_session_timeout 4h;
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers on;
@@ -194,6 +204,12 @@ This setup is called a "reverse proxy": NGINX provides secure communication to t
 
   ```sh
   $ sudo mkdir /etc/nginx/streams-enabled
+  ```
+
+* Disable NGINX's default site
+
+  ```sh
+  $ sudo rm /etc/nginx/sites-enabled/default
   ```
 
 * Test this barebone Nginx configuration


### PR DESCRIPTION
#### What
 
This PR proposes separating the reverse proxying of websites from pure TCP stream data (for now this is only electrs), so that these sites can be automatically redirected to HTTPS when the end user doesn't write the full URL in the browser.

#### Why

The current NGINX configuration is very simple and easy to maintain, but the `stream` directive cannot observe the traffic so it is unable to redirect HTTP requests to HTTPS.

Because of this, currently when the user types (for instance) `192.168.0.100:4000` in his browser, NGINX shows an error instead of redirecting automatically to `https://192.168.0.100:4000`.

By adding an `http` directive to `nginx.conf` that maps to `/etc/nginx/sites-enabled` we can use this directory to set up websites with HTTPS redirect. In the configuration file of each website, the `error_page 497 ...` directive makes the redirect when necessary: https://chrisguitarguy.com/2019/08/20/redirecting-http-requests-on-an-https-listener-in-nginx-status-code-497/

#### Scope

- [X] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

Fixes # (link issue)

#### Test & maintenance

:exclamation: I searched for `nginx` usages in all the project, but for now I only tested these changes in the BTC RCP Explorer.