### PR TITLE
[UPDATE] Added recommended command to signature check

### DIFF
--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -73,6 +73,13 @@ Expected output:
 * Bitcoin releases are signed by a number of individuals, each using its own key.
 In order to verify the validity of these signatures, you must first import the corresponding public keys into your GPG key database.
 
+
+* **Recommended command**, it automatically downloads and imports all signatures from the bitcoin core repository. make sure you have curl and jq installed on your system.
+  ```sh
+  $ curl 'https://api.github.com/repositories/355107265/contents/builder-keys' | jq '.[] .download_url' | xargs -L1 wget -N && curl 'https://api.github.com/repositories/355107265/contents/builder-keys' | jq '.[] .name' | xargs -L1 gpg --import
+  ```
+* Another option, you just need curl installed on your system to be able to run it, however this option requires copy/paste of each link and these may change over time.
+
   ```sh
   $ curl https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main/builder-keys/achow101.gpg | gpg --import &&
   curl https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main/builder-keys/fanquake.gpg | gpg --import &&

--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -71,23 +71,10 @@ Expected output:
 ### Signature check
 
 * Bitcoin releases are signed by a number of individuals, each using its own key.
-In order to verify the validity of these signatures, you must first import the corresponding public keys into your GPG key database.
+In order to verify the validity of these signatures, you must first import the corresponding public keys into your GPG key database. The next command download and imports automatically all signatures from the Bitcoin Core Guix repository.
 
-
-* **Recommended command**, it automatically downloads and imports all signatures from the bitcoin core repository. make sure you have curl and jq installed on your system.
   ```sh
   $ curl 'https://api.github.com/repositories/355107265/contents/builder-keys' | jq '.[] .download_url' | xargs -L1 wget -N && curl 'https://api.github.com/repositories/355107265/contents/builder-keys' | jq '.[] .name' | xargs -L1 gpg --import
-  ```
-* Another option, you just need curl installed on your system to be able to run it, however this option requires copy/paste of each link and these may change over time.
-
-  ```sh
-  $ curl https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main/builder-keys/achow101.gpg | gpg --import &&
-  curl https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main/builder-keys/fanquake.gpg | gpg --import &&
-  curl https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main/builder-keys/guggero.gpg | gpg --import &&
-  curl https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main/builder-keys/hebasto.gpg | gpg --import &&
-  curl https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main/builder-keys/theStack.gpg | gpg --import &&
-  curl https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main/builder-keys/vertiond.gpg | gpg --import &&
-  curl https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main/builder-keys/willyko.gpg | gpg --import
   ```
 
 Expexted output:

--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -71,7 +71,21 @@ Expected output:
 ### Signature check
 
 * Bitcoin releases are signed by a number of individuals, each using its own key.
-In order to verify the validity of these signatures, you must first import the corresponding public keys into your GPG key database. The next command download and imports automatically all signatures from the Bitcoin Core Guix repository.
+In order to verify the validity of these signatures, you must first import the corresponding public keys into your GPG key database.
+
+* Create .gnupg folder
+
+  ```sh
+  $ gpg --list-keys
+  ```
+
+* Enter to the .gnupg folder, create a persistent folder for the signatures and enter on it
+
+  ```sh
+  $ cd /home/admin/.gnupg/ && .mkdir sigs && cd sigs
+  ```
+
+* The next command download and imports automatically all signatures from the Bitcoin Core Guix repository.
 
   ```sh
   $ curl 'https://api.github.com/repositories/355107265/contents/builder-keys' | jq '.[] .download_url' | xargs -L1 wget -N && curl 'https://api.github.com/repositories/355107265/contents/builder-keys' | jq '.[] .name' | xargs -L1 gpg --import
@@ -80,7 +94,6 @@ In order to verify the validity of these signatures, you must first import the c
 Expexted output:
 
   ```sh
-  > gpg: directory '/home/admin/.gnupg' created
   > gpg: keybox '/home/admin/.gnupg/pubring.kbx' created
   >   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
   >                                 Dload  Upload   Total   Spent    Left  Speed
@@ -100,6 +113,12 @@ Expexted output:
   > gpg:               imported: 1
   > gpg: no ultimately trusted keys found
   [...]
+  ```
+
+* Return to the `tmp` folder
+
+  ```sh
+  $ cd /tmp
   ```
 
 * Verify that the checksums file is cryptographically signed by the release signing keys.
@@ -617,25 +636,22 @@ Expected output:
   > bitcoin-24.0.1-x86_64-linux-gnu.tar.gz: OK
   ```
 
-* Update gpg keys and verify checksums signatures
+* Enter to the `sigs` folder
 
   ```sh
-  $ wget https://raw.githubusercontent.com/bitcoin/bitcoin/master/contrib/builder-keys/keys.txt -O keys.txt
-  $ while read fingerprint keyholder_name; do gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys ${fingerprint}; done < ./keys.txt
+  $ cd /home/admin/.gnupg/sigs
   ```
 
-Expexted output:
+* The next command download and imports automatically all signatures from the Bitcoin Core Guix repository and update our database it if necessary
 
   ```sh
-  > gpg: key 188CBB2648416AD5: public key ".0xB10C <b10c@b10c.me>" imported
-  > gpg: Total number processed: 1
-  > gpg:               imported: 1
-  > gpg: key 0A41BDC3F4FAFF1C: "Aaron Clauson (sipsorcery) <aaron@sipsorcery.com>" not changed
-  > gpg: Total number processed: 1
-  > gpg:              unchanged: 1
-  > gpg: key 4BB42E31C79111B8: "Akira Takizawa (Ethereum Social Official) <info@ethereumsocial.kr>" not changed
-  > gpg: Total number processed: 1
-  [...]
+  $ curl 'https://api.github.com/repositories/355107265/contents/builder-keys' | jq '.[] .download_url' | xargs -L1 wget -N && curl 'https://api.github.com/repositories/355107265/contents/builder-keys' | jq '.[] .name' | xargs -L1 gpg --import
+  ```
+
+* Return to the `tmp` folder
+
+  ```sh
+  $ cd /tmp
   ```
 
 * Verify that the checksums file is cryptographically signed by the release signing keys.
@@ -645,10 +661,10 @@ Expexted output:
   $ gpg --verify SHA256SUMS.asc
   ```
 
-Check that at least a few signatures show the following text
+* Check that at least a few signatures show the following text
 
   ```sh
-  > gpg: **Good signature from** ...
+  > gpg: Good signature from ...
   > Primary key fingerprint: ...
   ```
 

--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -73,7 +73,7 @@ Expected output:
 * Bitcoin releases are signed by a number of individuals, each using its own key.
 In order to verify the validity of these signatures, you must first import the corresponding public keys into your GPG key database.
 
-* Create .gnupg folder
+* Create ".gnupg" folder
 
   ```sh
   $ gpg --list-keys
@@ -85,7 +85,7 @@ In order to verify the validity of these signatures, you must first import the c
   $ cd /home/admin/.gnupg/ && .mkdir sigs && cd sigs
   ```
 
-* The next command download and imports automatically all signatures from the Bitcoin Core Guix repository.
+* The next command download and imports automatically all signatures from the [Bitcoin Core release attestations (Guix)](https://github.com/bitcoin-core/guix.sigs) repository.
 
   ```sh
   $ curl 'https://api.github.com/repositories/355107265/contents/builder-keys' | jq '.[] .download_url' | xargs -L1 wget -N && curl 'https://api.github.com/repositories/355107265/contents/builder-keys' | jq '.[] .name' | xargs -L1 gpg --import
@@ -642,7 +642,7 @@ Expected output:
   $ cd /home/admin/.gnupg/sigs
   ```
 
-* The next command download and imports automatically all signatures from the Bitcoin Core Guix repository and update our database it if necessary
+* The next command download and imports automatically all signatures from the Bitcoin Core Guix repository and update our database if necessary
 
   ```sh
   $ curl 'https://api.github.com/repositories/355107265/contents/builder-keys' | jq '.[] .download_url' | xargs -L1 wget -N && curl 'https://api.github.com/repositories/355107265/contents/builder-keys' | jq '.[] .name' | xargs -L1 gpg --import


### PR DESCRIPTION
The proposed command has the advantage that each time it is executed it downloads the entire directory of keys from the bitcoin core repository and imports them into your keyring, so you don't have to constantly update the key links in minibolt.

The command uses curl to do get from the github api where you can find the download links to the keys, with jq you parse the json from the api and download them with wget, then import the keys to your keyring with gpg --import