### PR TITLE
[UPDATE MAIN GUIDE] send bitcoind logs to stdout and let systemd pick them up

### DIFF
--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -367,6 +367,11 @@ We use "systemd", a daemon that controls the startup process using configuration
   ```sh
   $ sudo systemctl enable bitcoind
   ```
+* Prepare “bitcoind” monitoring by the systemd journal and check log logging output. You can exit monitoring at any time by with Ctrl-C
+
+  ```sh
+  $ sudo journalctl -f -u bitcoind.service
+  ```
 
 ## Running bitcoind
 
@@ -377,12 +382,6 @@ Commands for the **second session** start with the prompt `$2` (which must not b
 
   ```sh
   $2 sudo systemctl start bitcoind
-  ```
-
-* Return to the first terminal session to monitor "bitcoind". You can exit monitoring at any time with `Ctrl-C`
-
-  ```sh
-  $ sudo journalctl -f -u bitcoind.service
   ```
 
 Expected output:

--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -272,9 +272,12 @@ We'll also set the proper access permissions.
   # Aditional logs
   debug=tor
   debug=i2p
-  
+
   # Assign read permission to the Bitcoin group users 
   startupnotify=chmod g+r /home/bitcoin/.bitcoin/.cookie
+
+  # Disable debug.log
+  nodebuglogfile=1
 
   # Enable all compact filters
   blockfilterindex=1
@@ -341,7 +344,7 @@ We use "systemd", a daemon that controls the startup process using configuration
                                     -pid=/run/bitcoind/bitcoind.pid \
                                     -conf=/home/bitcoin/.bitcoin/bitcoin.conf \
                                     -datadir=/home/bitcoin/.bitcoin
-  Type=forking
+  Type=exec
   PIDFile=/run/bitcoind/bitcoind.pid
   Restart=on-failure
   TimeoutSec=300

--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -340,8 +340,7 @@ We use "systemd", a daemon that controls the startup process using configuration
   PartOf=tor.service i2pd.service
 
   [Service]
-  ExecStart=/usr/local/bin/bitcoind -daemon \
-                                    -pid=/run/bitcoind/bitcoind.pid \
+  ExecStart=/usr/local/bin/bitcoind -pid=/run/bitcoind/bitcoind.pid \
                                     -conf=/home/bitcoin/.bitcoin/bitcoin.conf \
                                     -datadir=/home/bitcoin/.bitcoin
   Type=exec

--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -380,16 +380,10 @@ Commands for the **second session** start with the prompt `$2` (which must not b
   $2 sudo systemctl start bitcoind
   ```
 
-* Grant the "bitcoin" group read permission for the debug log file
+* Return to the first terminal session to monitor "bitcoind". You can exit monitoring at any time with `Ctrl-C`
 
   ```sh
-  $2 sudo chmod g+r /data/bitcoin/debug.log
-  ```
-
-* Return to the first terminal session to monitor "bitcoind" by its log file now available. You can exit monitoring at any time with `Ctrl-C`
-
-  ```sh
-  $ sudo tail --lines 500 -f /home/bitcoin/.bitcoin/debug.log
+  $ sudo journalctl -f -u bitcoind.service
   ```
 
 Expected output:

--- a/guide/bonus/bitcoin/electrum-personal-server.md
+++ b/guide/bonus/bitcoin/electrum-personal-server.md
@@ -170,7 +170,7 @@ The Electrum Personal Server scripts are installed in the directory `/home/bitco
 * You can monitor the rescan progress in the Bitcoin Core logfile from a second SSH session:
 
   ```sh
-  $ sudo tail -f /home/bitcoin/.bitcoin/debug.log
+  $ sudo journalctl -f -u bitcoind.service
   ```
 
 * Run Electrum Personal Server again and connect your Electrum wallet from your regular computer.

--- a/resources/.bash_aliases
+++ b/resources/.bash_aliases
@@ -132,7 +132,7 @@ alias disableallmain='sudo systemctl disable bitcoind fulcrum btcrpcexplorer lnd
 
 alias torlogs='sudo journalctl -f -u tor@default'
 alias i2plogs='sudo tail -f /var/log/i2pd/i2pd.log'
-alias bitcoindlogs='sudo tail -f /home/bitcoin/.bitcoin/debug.log'
+alias bitcoindlogs='sudo journalctl -f -u bitcoind.service'
 alias fulcrumlogs='sudo journalctl -f -u fulcrum'
 alias btcrpcexplorerlogs='sudo journalctl -f -u btcrpcexplorer'
 alias lndlogs='sudo journalctl -f -u lnd'


### PR DESCRIPTION
#### What

This PR proposes that `bitcoind` send its logs to standard output instead of the `debug.log` file. With this change `journald` reads and process the logs like those of any other system service.

#### Why

This change has, in my opinion, a couple benefits:

1. bitcoind logs are queried with `journalctl` like any other system service, allowing more [nuanced queries](https://linuxhandbook.com/journalctl-command/). For instance:
```
$ journalctl --since "yesterday" --until "-3 hour" -u bitcoind.service
```

2. As part of its duties `systemd-journald` takes care of prunning old logs. With `debug.log` we have an unmanaged file that always grows and has to be pruned manually from time to time by the node operator.

#### How

`nodebuglogfile=1` turns off file logging and turns on STDOUT output. A change in the type of systemd service is also needed for journald to be able to read the logs: https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=

#### Scope

- [x] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix
