### PR TITLE
Bitcoin blockchain size increased to 465GB

### DIFF
--- a/guide/bitcoin/bitcoin-client.md
+++ b/guide/bitcoin/bitcoin-client.md
@@ -29,7 +29,7 @@ We install [Bitcoin Core](https://bitcoin.org/en/bitcoin-core/){:target="_blank"
 ## This may take some time
 
 Bitcoin Core will download the full Bitcoin blockchain, and validate all transactions since 2009.
-We're talking more than 700'000 blocks with a size of over 430 GB, so this is not an easy task.
+We're talking more than 700'000 blocks with a size of over 465 GB, so this is not an easy task.
 
 ---
 

--- a/guide/system/preparations.md
+++ b/guide/system/preparations.md
@@ -42,7 +42,7 @@ You need the following hardware:
 * Temporary monitor screen or television
 * Temporary keyboard USB/PS2
 
-The complete Bitcoin blockchain must be stored locally to run a Lightning node, currently about 430 GB and growing.
+The complete Bitcoin blockchain must be stored locally to run a Lightning node, currently about 465 GB and growing.
 
 You might also want to get this optional hardware:
 


### PR DESCRIPTION
#### What

The size of the bitcoin blockchain has increased from 430 GB to 465 GB

#### Why

This change will help the minibolt documentation present more accurate information, as well as help me contribute to a project that I care about.

#### How

Replaced previous "430" instances with "465" instead.


#### Test & maintenance

How can the changes be tested?
Went to https://blockchair.com/bitcoin/charts/blockchain-size, downloaded the .tsv file, opened the .tsv with LibreOffice, got the current blockchain size that way.