### PR TITLE
build BerkeleyDB 4.8 to support legacy wallets

### DIFF
--- a/guide/bonus/bitcoin/ordisrespector.md
+++ b/guide/bonus/bitcoin/ordisrespector.md
@@ -151,7 +151,7 @@ The following command prints signature checks for each of the public keys that s
 
 Expected output:
 
-  ```sh
+  ```
   > gpg: Good signature from ...
   > Primary key fingerprint: ...
   [...]
@@ -169,7 +169,13 @@ Expected output:
 
   ```sh
   $ wget -O bdb.sh https://raw.githubusercontent.com/bitcoin/bitcoin/aef8b4f43b0c4300aa6cf2c5cf5c19f55e73499c/contrib/install_db4.sh
+  ```
+  
+  ```sh
   $ chmod +x bdb.sh
+  ```
+  
+  ```sh
   $ ./bdb.sh bitcoin-$VERSION
   ```
 

--- a/guide/bonus/bitcoin/ordisrespector.md
+++ b/guide/bonus/bitcoin/ordisrespector.md
@@ -165,6 +165,14 @@ Expected output:
 
 ### **Build it from the source code**
 
+* Build BerkeleyDB 4.8 to allow for legacy wallets, necessary to use JoinMarket, Electrum Personal Server, and possibly other tools:
+
+  ```sh
+  $ wget -O bdb.sh https://raw.githubusercontent.com/bitcoin/bitcoin/aef8b4f43b0c4300aa6cf2c5cf5c19f55e73499c/contrib/install_db4.sh
+  $ chmod +x bdb.sh
+  $ ./bdb.sh bitcoin-$VERSION
+  ```
+
 * Enter the Bitcoin Core source code folder
 
   ```sh
@@ -180,7 +188,9 @@ Expected output:
 * The next command will pre-configure the installation, we will discard some features and include others. Enter the complete next command in the terminal and press enter
 
   ```sh
+  export BDB_PREFIX="/tmp/bitcoin-$VERSION/db4"
   ./configure \
+     BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include" \
     --disable-bench \
     --disable-gui-tests \
     --disable-maintainer-mode \


### PR DESCRIPTION
Needed for Electrum Personal Wallet, JoinMarket, and for sure other tools. Tested and working on my setup.

#### What

Adds commands to build and configure BerkeleyDB in bitcoin core build.

#### Why

Almost messed up my node because I knew nothing about what was up, got a wallet loading error, migrated wallet, only to discover my main tools stopped working.
Luckily migrate tool makes a backup, but I still wanted ordisrespector AND JM/eps to work.

#### How

Hard work, time and dedication, all unpaid.

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x ] simple bug fix

Fixes # (link issue)

#### Test & maintenance

Just follow the guide.

#### Animated GIF (optional)

Add some snazz if you feel like it :)
