### PR TITLE
Tor version updated from 0.4.7.10 to 0.4.7.13

### DIFF
--- a/guide/system/privacy.md
+++ b/guide/system/privacy.md
@@ -86,7 +86,7 @@ Log in to your MiniBolt via SSH as user "admin" and install Tor.
 
   ```sh
   $ tor --version
-  > Tor version 0.4.7.10.
+  > Tor version 0.4.7.13.
   [...]
   ```
 


### PR DESCRIPTION
#### What

Tor's version is now 0.4.7.13 as seen when following this minibolt guide.  Minibolt shows it as 0.4.7.10.

This is my first time ever doing a Pull Request using github.

A cut-and-paste of what I saw when following the guide is at https://pastebin.com/QMjH1pxx

#### Why

Me getting used to github, and making minibolt better at the same time.

#### How

See https://pastebin.com/QMjH1pxx

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

Fixes # (link issue)

#### Test & maintenance

How can the changes be tested? Is there ongoing maintenance effort? If this is a bonus guide: are you willing to update it from time to time?

#### Animated GIF (optional)

Add some snazz if you feel like it :)
